### PR TITLE
Improve GIF compatibility

### DIFF
--- a/arm9/source/gif.hpp
+++ b/arm9/source/gif.hpp
@@ -72,7 +72,7 @@ class Gif {
 
 	std::vector<Frame> _frames;
 	std::vector<u16> _gct; // In DS format
-	u16 _loopCount = 0xFFFF;
+	u16 _loopCount = 0;
 	bool _top = false;
 	bool _compressed = false;
 


### PR DESCRIPTION
Just the same thing as DS-Homebrew/TWiLightMenu#1381 to keep GIF compatibility the same.

- Makes NetScape loop count `0` be loop forever, no NetScape block for loop once
- Makes delays below 2 actually be 10