### PR TITLE
Fix no loop GIFs being treated as infinite

### DIFF
--- a/arm9/source/gif.cpp
+++ b/arm9/source/gif.cpp
@@ -127,6 +127,9 @@ bool Gif::load(const char *path, bool top, bool animate, bool forceDecompress) {
 		}
 	}
 
+	// Set default loop count to 0, uninitialized default is 0xFFFF so it's infinite
+	_loopCount = 0;
+
 	Frame frame;
 	while (1) {
 		switch (fgetc(file)) {


### PR DESCRIPTION
as the title says, just copying over a little derp fix from DS-Homebrew/TWiLightMenu#1613.