### PR TITLE
Fix TWLBot Release message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,10 @@ jobs:
           echo ::set-output name=commit_hash::$(git log --format=%h -1)
 
           # Webhook info
-          echo ::set-output name=author_name::$(git log -1 "$GITHUB_SHA" --pretty="%aN")
-          echo ::set-output name=committer_name::$(git log -1 "$GITHUB_SHA" --pretty="%cN")
-          echo ::set-output name=commit_subject::$(git log -1 "$GITHUB_SHA" --pretty="%s")
-          echo ::set-output name=commit_message::$(git log -1 "$GITHUB_SHA" --pretty="%b")
+          echo "::set-output name=author_name::$(git log -1 $GITHUB_SHA --pretty=%aN)"
+          echo "::set-output name=committer_name::$(git log -1 $GITHUB_SHA --pretty=%cN)"
+          echo "::set-output name=commit_subject::$(git log -1 $GITHUB_SHA --pretty=%s)"
+          echo "::set-output name=commit_message::$(git log -1 $GITHUB_SHA --pretty=%b)"
       - name: Pack 7z for nightly
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
         run: |
@@ -75,6 +75,7 @@ jobs:
       COMMIT_TAG: ${{ needs.build.outputs.commit_tag }}
       COMMIT_HASH: ${{ needs.build.outputs.commit_hash }}
       AUTHOR_NAME: ${{ needs.build.outputs.author_name }}
+      COMMIT_SUBJECT: ${{ needs.build.outputs.commit_subject }}
       COMMIT_MESSAGE: ${{ needs.build.outputs.commit_message }}
     outputs:
       current_date: ${{ steps.commit.outputs.current_date }}
@@ -120,7 +121,7 @@ jobs:
           AUTH_HEADER="Authorization: token ${{ secrets.TWLBOT_TOKEN }}"
           CONTENT_TYPE="Content-Type: application/json"
           API_URL="https://api.github.com/repos/TWLBot/Builds/releases"
-          RELEASE_INFO="{\"tag_name\": \"v${{ steps.commit.outputs.current_date }}\", \"name\": \"hiyaCFW | $COMMIT_HASH\", \"body\": \"$AUTHOR_NAME - $COMMIT_MESSAGE\", \"prerelease\": true}"
+          RELEASE_INFO="{\"tag_name\": \"v${{ steps.commit.outputs.current_date }}\", \"name\": \"hiyaCFW | $COMMIT_HASH\", \"body\": \"$AUTHOR_NAME - $COMMIT_SUBJECT\\n\\n$COMMIT_MESSAGE\", \"prerelease\": true}"
 
           RESPONSE=$(curl -XPOST -H "$AUTH_HEADER" -H "$CONTENT_TYPE" "$API_URL" -d "$RELEASE_INFO")
 


### PR DESCRIPTION
Fixes the TWLBot release's message being blank.

- Before: https://github.com/TWLBot/Builds/releases/tag/v20211004-065659
- After: https://github.com/TWLBot/Builds/releases/tag/v20211004-160211