### PR TITLE
Use old docker image of devkitpro/devkitarm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: devkitpro/devkitarm
+    container: devkitpro/devkitarm:20241104
     name: Build with Docker using devkitARM
     steps:
       - name: Checkout repo


### PR DESCRIPTION
For now, just use old docker image for building since we do not update it for calico yet.